### PR TITLE
Allow .Write() to be called multiple times

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,8 +71,10 @@ Reset permits reusing a Resampler rather than allocating a new one.
 #### func (*Resampler) Write
 
 ```go
-func (r *Resampler) Write(p []byte) (i int, err error)
+func (r *Resampler) Write(p []byte, stream bool) (i int, err error)
 ```
 Write resamples PCM sound data. Writes len(p) bytes from p to the underlying
 data stream, returns the number of bytes written from p (0 <= n <= len(p)) and
 any error encountered that caused the write to stop early.
+
+If `stream` is false, then no further data should be processed by this resampler until it is reset.

--- a/cmd/goresample.go
+++ b/cmd/goresample.go
@@ -82,7 +82,7 @@ func main() {
 		input = input[wavHeader:]
 	}
 	// Resample data and wrte to output file
-	i, err := res.Write(input)
+	i, err := res.Write(input, false)
 	res.Close()
 	output.Close()
 	if err != nil {

--- a/resample.go
+++ b/resample.go
@@ -147,7 +147,7 @@ func (r *Resampler) Close() (err error) {
 // the underlying data stream, returns the number of bytes written
 // from p (0 <= n <= len(p)) and any error encountered that caused
 // the write to stop early.
-func (r *Resampler) Write(p []byte) (i int, err error) {
+func (r *Resampler) Write(p []byte, stream bool) (i int, err error) {
 	if r.resampler == nil {
 		err = errors.New("soxr resampler is nil")
 		return
@@ -180,7 +180,7 @@ func (r *Resampler) Write(p []byte) (i int, err error) {
 			err = errors.New(C.GoString(soxErr))
 			goto cleanup
 		}
-		if int(read) == framesIn && int(done) < framesOut {
+		if int(read) == framesIn && int(done) < framesOut && !stream {
 			// Indicate end of input to the resampler
 			var d C.size_t = 0
 			soxErr = C.soxr_process(r.resampler, C.soxr_in_t(nil), C.size_t(0), nil, C.soxr_out_t(dataOut), C.size_t(framesOut), &d)
@@ -189,6 +189,7 @@ func (r *Resampler) Write(p []byte) (i int, err error) {
 				goto cleanup
 			}
 			done += d
+
 			break
 		}
 	}

--- a/resample_test.go
+++ b/resample_test.go
@@ -74,7 +74,7 @@ func TestWriter1(t *testing.T) {
 		t.Fatal("Failed to create a 1-1 Resampler: ", err)
 	}
 	for _, tc := range WriterTest1 {
-		i, err := res.Write(tc.data)
+		i, err := res.Write(tc.data, false)
 		res.Reset(ioutil.Discard)
 		if err != nil && err.Error() != tc.err {
 			t.Errorf("Resampler 1-1 writer error: %s , expecting: %s", err.Error(), tc.err)
@@ -107,7 +107,7 @@ func TestWriter2(t *testing.T) {
 		t.Fatal("Failed to create a 1-2 Resampler: ", err)
 	}
 	for _, tc := range WriterTest2 {
-		i, err := res.Write(tc.data)
+		i, err := res.Write(tc.data, false)
 		res.Reset(ioutil.Discard)
 		if err != nil && err.Error() != tc.err {
 			t.Errorf("Resampler 1-2 writer error: %s , expecting: %s", err.Error(), tc.err)
@@ -131,7 +131,7 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to Close the Resampler: ", err)
 	}
-	_, err = res.Write(WriterTest1[3].data)
+	_, err = res.Write(WriterTest1[3].data, false)
 	if err == nil {
 		t.Fatal("Running Write on a closed Resampler didn't return an error.")
 	}
@@ -196,7 +196,7 @@ func BenchmarkResampling(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err = res.Write(rawData[44:])
+				_, err = res.Write(rawData[44:], false)
 				if err != nil {
 					b.Fatalf("Encoding failed: %s\n", err)
 				}


### PR DESCRIPTION
This is a very small and hasty edit that allows resampling while on "stream" mode (say, if samples are being read on the fly and resampled as chunks). Without this, further calls to .Write will generate a segmentation fault.

Should further changes be necessary, just ask.