### PR TITLE
Add streaming input mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,32 +46,32 @@ Resampler resamples PCM sound data.
 #### func  New
 
 ```go
-func New(writer io.Writer, inputRate, outputRate float64, channels, format, quality int) (*Resampler, error)
+func New(writer io.Writer, inputRate, outputRate float64, channels, format, quality int, stream bool) (*Resampler, error)
 ```
 New returns a pointer to a Resampler that implements an io.WriteCloser. It takes
 as parameters the destination data Writer, the input and output sampling rates,
-the number of channels of the input data, the input format and the quality
-setting.
+the number of channels of the input data, the input format, the quality setting 
+and the imput mode (streaming or not).
 
 #### func (*Resampler) Close
 
 ```go
-func (r *Resampler) Close() (err error)
+func (r *Resampler) Close() (error)
 ```
-Close clean-ups and frees memory. Should always be called when finished using
+Close flushes, clean-ups and frees memory. Should always be called when finished using
 the resampler.
 
 #### func (*Resampler) Reset
 
 ```go
-func (r *Resampler) Reset(writer io.Writer) (err error)
+func (r *Resampler) Reset(writer io.Writer) (error)
 ```
 Reset permits reusing a Resampler rather than allocating a new one.
 
 #### func (*Resampler) Write
 
 ```go
-func (r *Resampler) Write(p []byte) (i int, err error)
+func (r *Resampler) Write(p []byte) (int, error)
 ```
 Write resamples PCM sound data. Writes len(p) bytes from p to the underlying
 data stream, returns the number of bytes written from p (0 <= n <= len(p)) and

--- a/cmd/stream/main.go
+++ b/cmd/stream/main.go
@@ -1,0 +1,117 @@
+/*
+	Copyright (C) 2016 - 2023, Lefteris Zafiris <zaf@fastmail.com>
+
+	This program is free software, distributed under the terms of
+	the BSD 3-Clause License. See the LICENSE file
+	at the top of the source tree.
+*/
+
+// The program takes as input a WAV or RAW PCM sound file
+// and resamples it to the desired sampling rate.
+// The output is RAW PCM data.
+// Usage: goresample [flags] input_file output_file
+//
+// Example: go run main.go -ir 16000 -or 8000 ../../testing/piano-16k-16-2.wav 8k.raw
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zaf/resample"
+)
+
+const wavHeader = 44
+
+var (
+	format = flag.String("format", "i16", "PCM format")
+	ch     = flag.Int("ch", 2, "Number of channels")
+	ir     = flag.Int("ir", 44100, "Input sample rate")
+	or     = flag.Int("or", 0, "Output sample rate")
+)
+
+func main() {
+	flag.Parse()
+	var frmt int
+	switch *format {
+	case "i16":
+		frmt = resample.I16
+	case "i32":
+		frmt = resample.I32
+	case "f32":
+		frmt = resample.F32
+	case "f64":
+		frmt = resample.F64
+	default:
+		log.Fatalln("Invalid Format")
+	}
+	if *ch < 1 {
+		log.Fatalln("Invalid channel number")
+	}
+	if *ir <= 0 || *or <= 0 {
+		log.Fatalln("Invalid input or output sample rate")
+	}
+	if flag.NArg() < 2 {
+		log.Fatalln("No input or output files given")
+	}
+	inputFile := flag.Arg(0)
+	outputFile := flag.Arg(1)
+	var err error
+
+	// Open input file (WAV or RAW PCM)
+	input, err := os.Open(inputFile)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer input.Close()
+	output, err := os.Create(outputFile)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// Create a streaming Resampler
+	res, err := resample.New(output, float64(*ir), float64(*or), *ch, frmt, resample.HighQ, true)
+	if err != nil {
+		output.Close()
+		os.Remove(outputFile)
+		log.Fatalln(err)
+	}
+	// Skip WAV file header in order to pass only the PCM data to the Resampler
+	if strings.ToLower(filepath.Ext(inputFile)) == ".wav" {
+		input.Seek(wavHeader, 0)
+	}
+
+	// Read input data in chunks and pass them to the Resampler
+	var read, written int
+	buf := make([]byte, 1024*1024)
+	for {
+		r, err := input.Read(buf)
+		if err != nil {
+			if err.Error() == "EOF" {
+				err = nil
+			}
+			break
+		}
+		read += r
+		w, err := res.Write(buf[:r])
+		if err != nil {
+			break
+		}
+		written += w
+	}
+	if err != nil {
+		os.Remove(outputFile)
+		log.Fatalln(err)
+	}
+	if written < read {
+		log.Println("Short write")
+	}
+	// Close the Resampler and the output file. Clsoing the Resampler will flush any remaining data to the output file.
+	// If the Resampler is not closed before the output file, any remaining data will be lost.
+	res.Close()
+	output.Close()
+
+}

--- a/resample.go
+++ b/resample.go
@@ -10,9 +10,9 @@
 Package resample implements resampling of PCM-encoded audio.
 It uses the SoX Resampler library `libsoxr'.
 
-To install make sure you have libsoxr installed, then run:
+To install make sure you have libsoxr and pkg-config installed, then run:
 
-go get -u github.com/zaf/resample
+go install github.com/zaf/resample@latest
 
 The package warps an io.Reader in a Resampler that resamples and
 writes all input data. Input should be RAW PCM encoded audio samples.
@@ -59,6 +59,7 @@ type Resampler struct {
 	outRate     float64   // output sample rate
 	channels    int       // number of input channels
 	frameSize   int       // frame size in bytes
+	stream      bool      // stream mode
 	destination io.Writer // output data
 }
 
@@ -70,9 +71,9 @@ func init() {
 
 // New returns a pointer to a Resampler that implements an io.WriteCloser.
 // It takes as parameters the destination data Writer, the input and output
-// sampling rates, the number of channels of the input data, the input format
-// and the quality setting.
-func New(writer io.Writer, inputRate, outputRate float64, channels, format, quality int) (*Resampler, error) {
+// sampling rates, the number of channels of the input data, the input format,
+// the quality setting and the imput mode (streaming or not).
+func New(writer io.Writer, inputRate, outputRate float64, channels, format, quality int, stream bool) (*Resampler, error) {
 	var err error
 	var size int
 	if writer == nil {
@@ -116,6 +117,7 @@ func New(writer io.Writer, inputRate, outputRate float64, channels, format, qual
 		outRate:     outputRate,
 		channels:    channels,
 		frameSize:   size,
+		stream:      stream,
 		destination: writer,
 	}
 	C.free(unsafe.Pointer(soxErr))
@@ -123,37 +125,46 @@ func New(writer io.Writer, inputRate, outputRate float64, channels, format, qual
 }
 
 // Reset permits reusing a Resampler rather than allocating a new one.
-func (r *Resampler) Reset(writer io.Writer) (err error) {
+func (r *Resampler) Reset(writer io.Writer) error {
+	var err error
 	if r.resampler == nil {
 		return errors.New("soxr resampler is nil")
+	}
+	if r.stream {
+		err = r.flush()
 	}
 	r.destination = writer
 	C.soxr_clear(r.resampler)
-	return
+	return err
 }
 
-// Close clean-ups and frees memory. Should always be called when
+// Close flushes, clean-ups and frees memory. Should always be called when
 // finished using the resampler.
-func (r *Resampler) Close() (err error) {
+func (r *Resampler) Close() error {
+	var err error
 	if r.resampler == nil {
 		return errors.New("soxr resampler is nil")
 	}
+	if r.stream {
+		err = r.flush()
+	}
 	C.soxr_delete(r.resampler)
 	r.resampler = nil
-	return
+	return err
 }
 
 // Write resamples PCM sound data. Writes len(p) bytes from p to
 // the underlying data stream, returns the number of bytes written
 // from p (0 <= n <= len(p)) and any error encountered that caused
 // the write to stop early.
-func (r *Resampler) Write(p []byte) (i int, err error) {
+func (r *Resampler) Write(p []byte) (int, error) {
+	var err error
+	var i int
 	if r.resampler == nil {
-		err = errors.New("soxr resampler is nil")
-		return
+		return i, errors.New("soxr resampler is nil")
 	}
 	if len(p) == 0 {
-		return
+		return i, nil
 	}
 	if fragment := len(p) % (r.frameSize * r.channels); fragment != 0 {
 		// Drop fragmented frames from the end of input data
@@ -161,42 +172,32 @@ func (r *Resampler) Write(p []byte) (i int, err error) {
 	}
 	framesIn := len(p) / r.frameSize / r.channels
 	if framesIn == 0 {
-		err = errors.New("Incomplete input frame data")
-		return
+		return i, errors.New("Incomplete input frame data")
 	}
 	framesOut := int(float64(framesIn) * (r.outRate / r.inRate))
 	if framesOut == 0 {
-		err = errors.New("Not enough input to generate output")
-		return
+		return i, errors.New("Not enough input to generate output")
 	}
 	dataIn := C.CBytes(p)
 	dataOut := C.malloc(C.size_t(framesOut * r.channels * r.frameSize))
 	var soxErr C.soxr_error_t
 	var read, done C.size_t = 0, 0
 	var written int
-	for int(done) < framesOut {
-		soxErr = C.soxr_process(r.resampler, C.soxr_in_t(dataIn), C.size_t(framesIn), &read, C.soxr_out_t(dataOut), C.size_t(framesOut), &done)
-		if C.GoString(soxErr) != "" && C.GoString(soxErr) != "0" {
-			err = errors.New(C.GoString(soxErr))
-			goto cleanup
-		}
-		if int(read) == framesIn && int(done) < framesOut {
-			// Indicate end of input to the resampler
-			var d C.size_t = 0
-			soxErr = C.soxr_process(r.resampler, C.soxr_in_t(nil), C.size_t(0), nil, C.soxr_out_t(dataOut), C.size_t(framesOut), &d)
-			if C.GoString(soxErr) != "" && C.GoString(soxErr) != "0" {
-				err = errors.New(C.GoString(soxErr))
-				goto cleanup
-			}
-			done += d
-			break
-		}
+	// By passing ^framesIn we notify end of input and tell soxr to process all input data. After that we cant pass any more input.
+	if !r.stream {
+		framesIn = ^framesIn
+	}
+	soxErr = C.soxr_process(r.resampler, C.soxr_in_t(dataIn), C.size_t(framesIn), &read, C.soxr_out_t(dataOut), C.size_t(framesOut), &done)
+	if C.GoString(soxErr) != "" && C.GoString(soxErr) != "0" {
+		err = errors.New(C.GoString(soxErr))
+		goto cleanup
 	}
 	written, err = r.destination.Write(C.GoBytes(dataOut, C.int(int(done)*r.channels*r.frameSize)))
+	//fmt.Println("written:", written, "done:", done, "read:", read, "framesIn:", framesIn, "framesOut:", framesOut)
 	i = int(float64(written) * (r.inRate / r.outRate))
 	// If we have read all input and flushed all output, avoid to report short writes due
 	// to output frames missing because of downsampling or other odd reasons.
-	if err == nil && framesIn == int(read) && framesOut == int(done) {
+	if err == nil && ((framesIn == int(read) && framesOut == int(done)) || r.stream) {
 		i = len(p)
 	}
 
@@ -204,5 +205,26 @@ cleanup:
 	C.free(dataIn)
 	C.free(dataOut)
 	C.free(unsafe.Pointer(soxErr))
-	return
+	return i, err
+}
+
+// flush any pending output from the resampler when in stream mode. Aftter that no more input can be passed.
+func (r *Resampler) flush() error {
+	var err error
+	var done C.size_t
+	var soxErr C.soxr_error_t
+	framesOut := 40960
+	dataOut := C.malloc(C.size_t(framesOut * r.channels * r.frameSize))
+	// Flush any pending output by calling soxr_process with no input data.
+	soxErr = C.soxr_process(r.resampler, nil, 0, nil, C.soxr_out_t(dataOut), C.size_t(framesOut), &done)
+	if C.GoString(soxErr) != "" && C.GoString(soxErr) != "0" {
+		err = errors.New(C.GoString(soxErr))
+		goto cleanup
+	}
+	_, err = r.destination.Write(C.GoBytes(dataOut, C.int(int(done)*r.channels*r.frameSize)))
+	//fmt.Println("flushed:", done)
+cleanup:
+	C.free(dataOut)
+	C.free(unsafe.Pointer(soxErr))
+	return err
 }

--- a/resample_test.go
+++ b/resample_test.go
@@ -21,29 +21,30 @@ var NewTest = []struct {
 	channels   int
 	format     int
 	quality    int
+	stream     bool
 	err        string
 }{
-	{writer: io.Discard, inputRate: 8000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I32, quality: MediumQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: F32, quality: MediumQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: F64, quality: MediumQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: Quick, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: LowQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: HighQ, err: ""},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: VeryHighQ, err: ""},
-	{writer: nil, inputRate: 8000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, err: "io.Writer is nil"},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 0, format: I16, quality: MediumQ, err: "Invalid channels number"},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 0.0, channels: 0, format: I16, quality: MediumQ, err: "Invalid input or output sampling rates"},
-	{writer: io.Discard, inputRate: 0.0, outputRate: 8000.0, channels: 0, format: I16, quality: MediumQ, err: "Invalid input or output sampling rates"},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: 10, quality: MediumQ, err: "Invalid format setting"},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: 10, err: "Invalid quality setting"},
-	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: -10, err: "Invalid quality setting"},
+	{writer: io.Discard, inputRate: 8000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, stream: false, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, stream: true, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I32, quality: MediumQ, stream: false, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: F32, quality: MediumQ, stream: true, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: F64, quality: MediumQ, stream: false, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: Quick, stream: true, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: LowQ, stream: false, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: HighQ, stream: false, err: ""},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: VeryHighQ, stream: false, err: ""},
+	{writer: nil, inputRate: 8000.0, outputRate: 8000.0, channels: 2, format: I16, quality: MediumQ, stream: false, err: "io.Writer is nil"},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 0, format: I16, quality: MediumQ, stream: false, err: "Invalid channels number"},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 0.0, channels: 0, format: I16, quality: MediumQ, stream: false, err: "Invalid input or output sampling rates"},
+	{writer: io.Discard, inputRate: 0.0, outputRate: 8000.0, channels: 0, format: I16, quality: MediumQ, stream: false, err: "Invalid input or output sampling rates"},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: 10, quality: MediumQ, stream: false, err: "Invalid format setting"},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: 10, stream: false, err: "Invalid quality setting"},
+	{writer: io.Discard, inputRate: 16000.0, outputRate: 8000.0, channels: 2, format: I16, quality: -10, stream: false, err: "Invalid quality setting"},
 }
 
 func TestNew(t *testing.T) {
 	for _, tc := range NewTest {
-		res, err := New(tc.writer, tc.inputRate, tc.outputRate, tc.channels, tc.format, tc.quality)
+		res, err := New(tc.writer, tc.inputRate, tc.outputRate, tc.channels, tc.format, tc.quality, tc.stream)
 		if err != nil && tc.err != err.Error() {
 			t.Fatalf("Expecting: %s got: %v", tc.err, err)
 		}
@@ -69,24 +70,26 @@ var WriterTest1 = []struct {
 }
 
 func TestWriter1(t *testing.T) {
-	res, err := New(io.Discard, 8000.0, 8000.0, 1, I16, MediumQ)
-	if err != nil {
-		t.Fatal("Failed to create a 1-1 Resampler: ", err)
-	}
-	for _, tc := range WriterTest1 {
-		i, err := res.Write(tc.data)
-		res.Reset(io.Discard)
-		if err != nil && err.Error() != tc.err {
-			t.Errorf("Resampler 1-1 writer error: %s , expecting: %s", err.Error(), tc.err)
-		}
+	for _, stream := range []bool{true, false} {
+		res, err := New(io.Discard, 8000.0, 8000.0, 1, I16, MediumQ, stream)
 		if err != nil {
-			continue
+			t.Fatal("Failed to create a 1-1 Resampler: Stream:", stream, "Error:", err)
 		}
-		if i != tc.expected {
-			t.Errorf("Resampler 1-1 writer returned: %d , expecting: %d", i, tc.expected)
+		for _, tc := range WriterTest1 {
+			i, err := res.Write(tc.data)
+			res.Reset(io.Discard)
+			if err != nil && err.Error() != tc.err {
+				t.Errorf("Resampler 1-1 writer: stream: %t, error: %s, expecting: %s", stream, err.Error(), tc.err)
+			}
+			if err != nil {
+				continue
+			}
+			if i != tc.expected {
+				t.Errorf("Resampler 1-1 writer: tream: %t, returned: %d, expecting: %d", stream, i, tc.expected)
+			}
 		}
+		res.Close()
 	}
-	res.Close()
 }
 
 var WriterTest2 = []struct {
@@ -102,61 +105,67 @@ var WriterTest2 = []struct {
 }
 
 func TestWriter2(t *testing.T) {
-	res, err := New(io.Discard, 8000.0, 4000.0, 2, I16, MediumQ)
-	if err != nil {
-		t.Fatal("Failed to create a 1-2 Resampler: ", err)
-	}
-	for _, tc := range WriterTest2 {
-		i, err := res.Write(tc.data)
-		res.Reset(io.Discard)
-		if err != nil && err.Error() != tc.err {
-			t.Errorf("Resampler 1-2 writer error: %s , expecting: %s", err.Error(), tc.err)
-		}
+	for _, stream := range []bool{true, false} {
+		res, err := New(io.Discard, 8000.0, 4000.0, 2, I16, MediumQ, stream)
 		if err != nil {
-			continue
+			t.Fatal("Failed to create a 1-2 Resampler: Stream:", stream, "Error:", err)
 		}
-		if i != tc.expected {
-			t.Errorf("Resampler 1-2 writer returned: %d , expecting: %d", i, tc.expected)
+		for _, tc := range WriterTest2 {
+			i, err := res.Write(tc.data)
+			res.Reset(io.Discard)
+			if err != nil && err.Error() != tc.err {
+				t.Errorf("Resampler 1-2 writer: stream %t, error: %s, expecting: %s", stream, err.Error(), tc.err)
+			}
+			if err != nil {
+				continue
+			}
+			if i != tc.expected {
+				t.Errorf("Resampler 1-2 writer: stream: %t, returned: %d , expecting: %d", stream, i, tc.expected)
+			}
 		}
+		res.Close()
 	}
-	res.Close()
 }
 
 func TestClose(t *testing.T) {
-	res, err := New(io.Discard, 16000.0, 8000.0, 1, I16, MediumQ)
-	if err != nil {
-		t.Fatal("Failed to create a Resampler: ", err)
-	}
-	err = res.Close()
-	if err != nil {
-		t.Fatal("Failed to Close the Resampler: ", err)
-	}
-	_, err = res.Write(WriterTest1[3].data)
-	if err == nil {
-		t.Fatal("Running Write on a closed Resampler didn't return an error.")
-	}
-	err = res.Close()
-	if err == nil {
-		t.Fatal("Running Close on a closed Resampler didn't return an error.")
+	for _, stream := range []bool{true, false} {
+		res, err := New(io.Discard, 16000.0, 8000.0, 1, I16, MediumQ, stream)
+		if err != nil {
+			t.Fatal("Failed to create a Resampler: stream:", stream, err)
+		}
+		err = res.Close()
+		if err != nil {
+			t.Fatal("Failed to Close the Resampler: stream:", stream, err)
+		}
+		_, err = res.Write(WriterTest1[3].data)
+		if err == nil {
+			t.Fatal("Running Write on a closed Resampler didn't return an error.")
+		}
+		err = res.Close()
+		if err == nil {
+			t.Fatal("Running Close on a closed Resampler didn't return an error.")
+		}
 	}
 }
 
 func TestReset(t *testing.T) {
-	res, err := New(io.Discard, 16000.0, 8000.0, 1, I16, MediumQ)
-	if err != nil {
-		t.Fatal("Failed to create a Resampler: ", err)
-	}
-	err = res.Reset(io.Discard)
-	if err != nil {
-		t.Fatal("Failed to Reset the Resampler: ", err)
-	}
-	err = res.Close()
-	if err != nil {
-		t.Fatal("Failed to Close the Resampler: ", err)
-	}
-	err = res.Reset(io.Discard)
-	if err == nil {
-		t.Fatal("Running Reset on a closed Resampler didn't return an error.")
+	for _, stream := range []bool{true, false} {
+		res, err := New(io.Discard, 16000.0, 8000.0, 1, I16, MediumQ, stream)
+		if err != nil {
+			t.Fatal("Failed to create a Resampler: stream:", stream, err)
+		}
+		err = res.Reset(io.Discard)
+		if err != nil {
+			t.Fatal("Failed to Reset the Resampler: stream:", stream, err)
+		}
+		err = res.Close()
+		if err != nil {
+			t.Fatal("Failed to Close the Resampler: stream:", stream, err)
+		}
+		err = res.Reset(io.Discard)
+		if err == nil {
+			t.Fatal("Running Reset on a closed Resampler didn't return an error.")
+		}
 	}
 }
 
@@ -169,17 +178,18 @@ var BenchData = []struct {
 	channels int
 	format   int
 	quality  int
+	stream   bool
 }{
-	{"16bit 2 ch 44,1->16 Medium", "testing/piano-44.1k-16-2.wav", 44100.0, 16000.0, 2, I16, MediumQ},
-	{"16bit 2 ch 16->8    Medium", "testing/piano-16k-16-2.wav", 16000.0, 8000.0, 2, I16, MediumQ},
-	{"32fl  2 ch 44.1->8  Medium", "testing/piano-44.1k-32f-2.wav", 44100.0, 8000.0, 2, F32, MediumQ},
-	{"16bit 2 ch 44.1->48 Medium", "testing/piano-44.1k-16-2.wav", 44100.0, 48000.0, 2, I16, MediumQ},
-	{"16bit 2 ch 48->44.1 Medium", "testing/piano-48k-16-2.wav", 48000.0, 44100.0, 2, I16, MediumQ},
-	{"16bit 1 ch 16->8     Quick", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, Quick},
-	{"16bit 1 ch 16->8       Low", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, LowQ},
-	{"16bit 1 ch 16->8    Medium", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, MediumQ},
-	{"16bit 1 ch 16->8      High", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, HighQ},
-	{"16bit 1 ch 16->8  VeryHigh", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, VeryHighQ},
+	{"16bit 2 ch 44,1->16 Medium", "testing/piano-44.1k-16-2.wav", 44100.0, 16000.0, 2, I16, MediumQ, true},
+	{"16bit 2 ch 16->8    Medium", "testing/piano-16k-16-2.wav", 16000.0, 8000.0, 2, I16, MediumQ, true},
+	{"32fl  2 ch 44.1->8  Medium", "testing/piano-44.1k-32f-2.wav", 44100.0, 8000.0, 2, F32, MediumQ, true},
+	{"16bit 2 ch 44.1->48 Medium", "testing/piano-44.1k-16-2.wav", 44100.0, 48000.0, 2, I16, MediumQ, true},
+	{"16bit 2 ch 48->44.1 Medium", "testing/piano-48k-16-2.wav", 48000.0, 44100.0, 2, I16, MediumQ, true},
+	{"16bit 1 ch 16->8     Quick", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, Quick, true},
+	{"16bit 1 ch 16->8       Low", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, LowQ, true},
+	{"16bit 1 ch 16->8    Medium", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, MediumQ, true},
+	{"16bit 1 ch 16->8      High", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, HighQ, true},
+	{"16bit 1 ch 16->8  VeryHigh", "testing/piano-16k-16-1.wav", 16000.0, 8000.0, 1, I16, VeryHighQ, true},
 }
 
 func BenchmarkResampling(b *testing.B) {
@@ -190,7 +200,7 @@ func BenchmarkResampling(b *testing.B) {
 				b.Fatalf("Failed to read test data: %s\n", err)
 			}
 			b.SetBytes(int64(len(rawData[44:])))
-			res, err := New(io.Discard, bd.inRate, bd.outRate, bd.channels, bd.format, bd.quality)
+			res, err := New(io.Discard, bd.inRate, bd.outRate, bd.channels, bd.format, bd.quality, bd.stream)
 			if err != nil {
 				b.Fatalf("Failed to create Writer: %s\n", err)
 			}
@@ -200,7 +210,6 @@ func BenchmarkResampling(b *testing.B) {
 				if err != nil {
 					b.Fatalf("Encoding failed: %s\n", err)
 				}
-				res.Reset(io.Discard)
 			}
 			res.Close()
 		})


### PR DESCRIPTION
In stream mode the resampler Write() method can be called multiple times. Close() and Reset() flush any remaining data. In non-stream mode (the old default) all data are read processed once and no flushing is needed.
